### PR TITLE
# it would see an error when the socket is closed.

### DIFF
--- a/aiowebsocket/freams.py
+++ b/aiowebsocket/freams.py
@@ -289,6 +289,8 @@ class Frames:
 
         output.write(message)
         self.writer.write(output.getvalue())
+        # it would see an error when the socket is closed.
+        await self.writer.drain()
 
     async def receive_close(self):
         """ When you receive a message that


### PR DESCRIPTION
 async with AioWebSocket(uri) as aws:
        converse = aws.manipulator
        message = b'AioWebSocket - Async WebSocket Client'
        while True:
            await converse.send(message)
            print('{time}-Client send: {message}'
                  .format(time=datetime.now().strftime('%Y-%m-%d %H:%M:%S'), message=message))
The above code can not see an error when the socket is closed. need to call below code:
awati converse.writer.drain()

I think this code can add to send method